### PR TITLE
Added link of Software Architect Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,6 +1080,9 @@ npm run start
 
 Open a browser and see the app running at `http://localhost:3000/`
 
+## Roadmaps
+* [Software Architect Roadmap](https://roadmap.sh/software-architect) - A complete guide to become a Software Architect.
+
 ## Contributing
 Thank you for your contributions!
 


### PR DESCRIPTION
Hi @ryanmcdermott,

I came across your repository [3rs-of-software-architecture](https://github.com/ryanmcdermott/3rs-of-software-architecture) and found it to be a valuable resource for Software Architects.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Software Architect Roadmap"](https://roadmap.sh/software-architect). I took the initiative to submit a ["Pull Request"](https://github.com/ryanmcdermott/3rs-of-software-architecture/pull/3) adding it in a separate "Roadmaps" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz